### PR TITLE
Use SSL for p4dservice

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -1,0 +1,25 @@
+# C: Country Name - 2 letter code (default: US)
+C = US
+
+# ST: State or Province Name - full name (default: CA)
+ST = CA
+
+# L: Locality or City Name (default: Alameda)
+L = San Francisco
+
+# O: Organization or Company Name (default: Perforce Autogen Cert)
+O = Perforce Autogen Cert
+
+# OU = Organization Unit - division or unit
+OU =
+
+# CN: Common Name (usually the DNS name of the server)
+# (default: the current server's DNS name)
+CN = *.example.com
+
+# EX: number of days from today for certificate expiration
+# (default: 730, e.g. 2 years)
+EX = 730
+
+# UNITS: unit multiplier for expiration (defaults to "days")
+# Valid values: "secs", "mins", "hours"UNITS =

--- a/install-perforce
+++ b/install-perforce
@@ -1,4 +1,6 @@
 #!/bin/sh
+P4SSLDIR=/perforce_depot/ssl
+export P4SSLDIR=$P4SSLDIR
 
 wget ftp://ftp.perforce.com/perforce/r14.1/bin.linux26x86_64/p4d
 chmod +x p4d
@@ -8,6 +10,15 @@ sudo mkdir /perforce_depot
 sudo chown perforce /perforce_depot
 sudo mkdir /var/log/perforce
 sudo chown perforce /var/log/perforce
+wget https://raw.githubusercontent.com/Allar/linux-perforce-installer/master/config.txt
+sudo mkdir $P4SSLDIR
+vim config.txt
+cp config.txt $P4SSLDIR
+sudo chown perforce $P4SSLDIR
+sudo chown perforce $P4SSLDIR/*
+sudo chmod 700 $P4SSLDIR
+sudo chmod 700 $P4SSLDIR/*
+sudo -H -u perforce bash -c 'export P4SSLDIR=/perforce_depot/ssl; p4d -r /perforce_depot -Gc'
 sudo apt-get install daemon
 cd /etc/init.d
 wget https://raw.githubusercontent.com/Allar/linux-perforce-installer/master/p4dservice

--- a/p4dservice
+++ b/p4dservice
@@ -3,7 +3,8 @@
 export P4JOURNAL=/var/log/perforce/journal
 export P4LOG=/var/log/perforce/p4err
 export P4ROOT=/perforce_depot
-export P4PORT=1666
+export P4PORT=ssl:1666
+export P4SSLDIR=/perforce_depot/ssl
 
 PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"
 


### PR DESCRIPTION
By default SSL should be used on p4d unless you have very specific
reasons not to (ie a VPN.) This update will self sign some p4 certs for
you, which you can later go back and modify.
